### PR TITLE
Add option to make new selection replace existing selection

### DIFF
--- a/cmb2_post_search_field.php
+++ b/cmb2_post_search_field.php
@@ -11,11 +11,13 @@ License: GPLv2
 
 function cmb2_post_search_render_field( $field, $escaped_value, $object_id, $object_type, $field_type ) {
 	$select_type = $field->args( 'select_type' );
+	$select_behavior = $field->args( 'select_behavior' );
 
 	echo $field_type->input( array(
 		'data-search' => json_encode( array(
 			'posttype'   => $field->args( 'post_type' ),
 			'selecttype' => 'radio' == $select_type ? 'radio' : 'checkbox',
+			'selectbehavior' => 'replace' == $select_behavior ? 'replace' : 'add',
 			'errortxt'   => esc_attr( $field_type->_text( 'error_text', __( 'An error has occurred. Please reload the page and try again.' ) ) ),
 			'findtxt'    => esc_attr( $field_type->_text( 'find_text', __( 'Find Posts or Pages' ) ) ),
 		) ),
@@ -197,9 +199,14 @@ function cmb2_post_search_render_js(  $cmb_id, $object_id, $object_type, $cmb ) 
 			},
 
 			handleSelected: function( checked ) {
-				var existing = this.$idInput.val();
-				existing = existing ? existing + ', ' : '';
-				this.$idInput.val( existing + checked.join( ', ' ) );
+				if ( 'add' === this.selectbehavior ) {
+					var existing = this.$idInput.val();
+					existing = existing ? existing + ', ' : '';
+					this.$idInput.val( existing + checked.join( ', ' ) );
+				}
+				else {
+					this.$idInput.val( checked.join( ', ' ) );
+				}
 
 				this.close();
 			}


### PR DESCRIPTION
Adds a 'select_behavior' => 'replace' field option. Without it the plugin defaults to the existing behavior, referred to as 'add' in the code. With select_behavior set to 'replace', once you select a post(s) in the modal and click the "Select" button then it will replace the existing field value with the newly selected post(s) instead of adding to the existing field value.

Combined with select_type set to 'radio' this can ensure the user only ever attaches one post to the field at a time (unless they manually type in the post IDs like 74, 75).